### PR TITLE
Use Numba to speedup threshold_decomposition

### DIFF
--- a/properscoring/_utils.py
+++ b/properscoring/_utils.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+
+def move_axis_to_end(array, axis):
+    array = np.asarray(array)
+    return np.rollaxis(array, axis, start=array.ndim)
+
+
+def argsort_indices(a, axis=-1):
+    """Like argsort, but returns an index suitable for sorting the
+    the original array even if that array is multidimensional
+    """
+    a = np.asarray(a)
+    ind = list(np.ix_(*[np.arange(d) for d in a.shape]))
+    ind[axis] = a.argsort(axis)
+    return tuple(ind)

--- a/properscoring/tests/test_brier.py
+++ b/properscoring/tests/test_brier.py
@@ -1,9 +1,44 @@
 import unittest
+import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
 
-from properscoring import brier_score, threshold_decomposition
+from properscoring import brier_score, threshold_decomposition, crps_ensemble
+
+from properscoring.tests.utils import suppress_warnings
+
+
+def threshold_decomposition_alt(observations, forecasts, thresholds):
+    observations = np.asarray(observations)
+    thresholds = np.asarray(thresholds)
+    forecasts = np.asarray(forecasts)
+
+    def exceedances(x):
+        # NaN safe calculation of threshold exceedances
+        # add an extra dimension to `x` and broadcast `thresholds` so that it
+        # varies along that new dimension
+        with suppress_warnings('invalid value encountered in greater'):
+            exceeds = (x[..., np.newaxis] >
+                       thresholds.reshape((1,) * x.ndim + (-1,))
+                       ).astype(float)
+        if x.ndim == 0 and np.isnan(x):
+            exceeds[:] = np.nan
+        else:
+            exceeds[np.where(np.isnan(x))] = np.nan
+        return exceeds
+
+    binary_obs = exceedances(observations)
+    if observations.shape == forecasts.shape:
+        prob_forecast = exceedances(forecasts)
+    elif observations.shape == forecasts.shape[:-1]:
+        # axis=-2 should be the 'realization' axis, after swapping that axes
+        # to the end of forecasts and inserting one extra axis
+        with suppress_warnings('Mean of empty slice'):
+            prob_forecast = np.nanmean(exceedances(forecasts), axis=-2)
+    else:
+        raise AssertionError
+    return brier_score(binary_obs, prob_forecast)
 
 
 class TestBrierScore(unittest.TestCase):
@@ -33,3 +68,40 @@ class TestThresholdDecomposition(unittest.TestCase):
             assert_allclose(
                 threshold_decomposition(observations, forecasts, thresholds),
                 expected)
+
+    def test_crps_consistency(self):
+        # verify that we can integrate the brier scores to calculate CRPS
+        obs = np.random.RandomState(123).rand(100)
+        forecasts = np.random.RandomState(456).rand(100, 100)
+        thresholds = np.linspace(0, 1, num=10000)
+
+        td = threshold_decomposition(obs, forecasts, thresholds)
+        actual = td.sum(1) * (thresholds[1] - thresholds[0])
+        desired = crps_ensemble(obs, forecasts)
+        assert_allclose(actual, desired, atol=1e-4)
+
+    def test_alt_implemenation_consistency(self):
+        obs = np.random.RandomState(123).randn(100)
+        forecasts = np.random.RandomState(456).randn(100, 100)
+        thresholds = np.linspace(-2, 2, num=10)
+
+        actual = threshold_decomposition(obs, forecasts, thresholds)
+        desired = threshold_decomposition(obs, forecasts, thresholds)
+        assert_allclose(actual, desired, atol=1e-10)
+
+        obs[np.random.RandomState(231).rand(100) < 0.2] = np.nan
+        forecasts[np.random.RandomState(231).rand(100, 100) < 0.2] = np.nan
+        forecasts[:, ::8] = np.nan
+        forecasts[::8, :] = np.nan
+
+        actual = threshold_decomposition(obs, forecasts, thresholds)
+        desired = threshold_decomposition(obs, forecasts, thresholds)
+        assert_allclose(actual, desired, atol=1e-10)
+
+    def test_errors(self):
+        with self.assertRaisesRegexp(ValueError, 'must be 1D and sorted'):
+            threshold_decomposition(1, [0, 1, 2], [[1]])
+        with self.assertRaisesRegexp(ValueError, 'must be 1D and sorted'):
+            threshold_decomposition(1, [0, 1, 2], [1, 0.5])
+        with self.assertRaisesRegexp(ValueError, 'must have matching shapes'):
+            threshold_decomposition([1, 2], [0, 1, 2], [0.5])

--- a/properscoring/tests/test_utils.py
+++ b/properscoring/tests/test_utils.py
@@ -1,0 +1,26 @@
+import unittest
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from properscoring._utils import argsort_indices, move_axis_to_end
+
+
+class TestArgsortIndices(unittest.TestCase):
+    def test_argsort_indices(self):
+        x = np.random.randn(5, 6, 7)
+        for axis in [0, 1, 2, -1]:
+            expected = np.sort(x, axis=axis)
+            idx = argsort_indices(x, axis=axis)
+            assert_allclose(expected, x[idx])
+
+
+class TestMoveAxis(unittest.TestCase):
+    def test_move_axis_to_end(self):
+        x = np.random.randn(5, 6, 7)
+        for axis, expected in [(0, (6, 7, 5)),
+                               (1, (5, 7, 6)),
+                               (2, (5, 6, 7)),
+                               (-1, (5, 6, 7))]:
+            actual = move_axis_to_end(x, axis=axis).shape
+            self.assertEqual(actual, expected)

--- a/properscoring/tests/utils.py
+++ b/properscoring/tests/utils.py
@@ -1,0 +1,9 @@
+import warnings
+import contextlib
+
+
+@contextlib.contextmanager
+def suppress_warnings(msg=None):
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', msg)
+        yield


### PR DESCRIPTION
## Benchmark

Setup:

``` python
import properscoring as ps
import properscoring.tests.test_brier
import numpy as np

np.random.seed(123)
obs = np.random.rand(10000,)
forecasts = np.random.rand(10000, 100)
thresholds = np.linspace(-2, 2, num=100)
```

Old version:

```
>>> %timeit ps.tests.test_brier.threshold_decomposition_alt(obs, forecasts, thresholds)
1 loops, best of 3: 1.4 s per loop
```

New version:

```
>>> %timeit ps.threshold_decomposition(obs, forecasts, thresholds)
10 loops, best of 3: 37.6 ms per loop
```

cc @williamleeds @mogismog
